### PR TITLE
Switch to standard anonymous functions for 7.3 support

### DIFF
--- a/src/Schema/Full_Activation_Provider.php
+++ b/src/Schema/Full_Activation_Provider.php
@@ -63,7 +63,7 @@ class Full_Activation_Provider {
 		}
 
 		$this->did_register = true;
-		$this->container->bind( 'stellar_schema_fully_activated', fn() => true );
+		$this->container->bind( 'stellar_schema_fully_activated', static function() { return true; } );
 
 		/*
 		 * This block should be the only one capturing exceptions thrown in the context of

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -61,7 +61,7 @@ class Schema {
 
 		$container->singleton( static::class, static::class );
 		$container->get( static::class )->register();
-		$container->bind( 'stellarwp_schema_registered', fn() => true );
+		$container->bind( 'stellarwp_schema_registered', static function() { return true; } );
 	}
 
 	/**
@@ -92,7 +92,7 @@ class Schema {
 		$this->container->get( Full_Activation_Provider::class )->register();
 
 		// Set a flag in the container to indicate there was a full activation of the CT1 component.
-		$this->container->bind( 'stellarwp_schema_fully_activated', fn() => true );
+		$this->container->bind( 'stellarwp_schema_fully_activated', static function() { return true; } );
 
 		$this->register_hooks();
 	}


### PR DESCRIPTION
Arrow functions were introduced in PHP 7.4 https://www.php.net/manual/en/functions.arrow.php

Running this on PHP 7.3 results in `Parse error: syntax error, unexpected ‘=>’ (T_DOUBLE_ARROW), expecting ‘)’ in /wp-content/plugins/kadence-blocks-pro/vendor/vendor-prefixed/stellarwp/schema/src/Schema/Schema.php on line 70`