### PR TITLE
Prevent version_compare on null

### DIFF
--- a/src/Schema/Tables/Contracts/Table.php
+++ b/src/Schema/Tables/Contracts/Table.php
@@ -438,7 +438,7 @@ abstract class Table implements Schema_Interface {
 			// @todo Error?
 		}
 
-		$version_applied = $this->get_stored_version();
+		$version_applied = $this->get_stored_version() ?: '';
 		$current_version = $this->get_version();
 
 		return version_compare( $version_applied, $current_version, '==' );


### PR DESCRIPTION
The default value of `get_stored_version()` is `null` which can throw a deprecation when passed to `version_compare()` in newer PHP versions 

```Deprecated: version_compare(): Passing null to parameter #1 ($version1) of type string is deprecated``` 