### PR TITLE
Introduce truncate method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [unreleased] Unreleased
 
+## [1.1.8] 2025-01-10
+
+* Feature - Introduce truncate method which does what the empty_table method was doing. Update empty_table to actually empty the table instead of truncating it.
+* Tweak - Decide if we can create/update during this requests based on blog's status, preventing multiple "check" queries.
 
 ## [1.1.7] 2024-06-05
 

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -257,7 +257,7 @@ class Builder {
 	 */
 	public function up( $force = false ) {
 		if ( ! is_blog_installed() || wp_installing() ) {
-			return;
+			return [];
 		}
 
 		$results       = [];

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -256,11 +256,8 @@ class Builder {
 	 * @return array<mixed> A list of each creation or update result.
 	 */
 	public function up( $force = false ) {
-		try {
-			$this->db::table( 'posts' )->select ( 1 )->limit( 1 )->get();
-		} catch ( \Exception $e ) {
-			// Let's not try to create the tables on a blog that's missing the basic ones.
-			return [];
+		if ( ! is_blog_installed() || wp_installing() ) {
+			return;
 		}
 
 		$results       = [];

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -250,6 +250,7 @@ class Builder {
 	 * Creates or updates the custom tables the plugin will use.
 	 *
 	 * @since 1.0.0
+	 * @since 1.1.8 Decided if we can perform the queries based on blog's status.
 	 *
 	 * @param bool $force Whether to force the creation or update of the tables or not.
 	 *

--- a/src/Schema/Tables/Contracts/Table.php
+++ b/src/Schema/Tables/Contracts/Table.php
@@ -221,6 +221,28 @@ abstract class Table implements Schema_Interface {
 		$this_table = static::table_name( true );
 
 		$this->db::query( "SET foreign_key_checks = 0" );
+		$result = $this->db::query( "DELETE FROM {$this_table}" );
+		$this->db::query( "SET foreign_key_checks = 1" );
+
+		return $result;
+	}
+
+	/**
+	 * Truncates the custom table.
+	 *
+	 * @since TBD
+	 *
+	 * @return int|false The number of removed rows, or `false` to indicate a failure.
+	 */
+	public function truncate() {
+		if ( ! $this->exists() ) {
+			// There is really nothing to empty here.
+			return 0;
+		}
+
+		$this_table = static::table_name( true );
+
+		$this->db::query( "SET foreign_key_checks = 0" );
 		$result = $this->db::query( "TRUNCATE {$this_table}" );
 		$this->db::query( "SET foreign_key_checks = 1" );
 

--- a/src/Schema/Tables/Contracts/Table.php
+++ b/src/Schema/Tables/Contracts/Table.php
@@ -230,7 +230,7 @@ abstract class Table implements Schema_Interface {
 	/**
 	 * Truncates the custom table.
 	 *
-	 * @since TBD
+	 * @since 1.1.8
 	 *
 	 * @return int|false The number of removed rows, or `false` to indicate a failure.
 	 */
@@ -557,7 +557,7 @@ abstract class Table implements Schema_Interface {
 	/**
 	 * Checks if a foreign key exists on a table.
 	 *
-	 * @since TBD
+	 * @since 1.1.3
 	 *
 	 * @param string $foreign_key The foreign key to check for.
 	 * @param string|null $table_name The table name to check. Defaults to the current table.


### PR DESCRIPTION
Introduces a `truncate` method that does what the `empty_table` was doing.

The reason is that `TRUCNATE` causes implicit commits - make it not suitable to be used during testing in most cases.

Now the method `empty_table` will simply delete everything from that table with the only difference not resseting the AUTO_INCREMENT if it exists. That should be ok.

Moreover it prevents multile "check" queries before deciding if we can or cant update the tables during the current request.