### PR TITLE
Revert "Prevent multiple "check" queries"

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -264,7 +264,7 @@ class Builder {
 	 */
 	public function up( $force = false ) {
 		try {
-			$this->db::table( 'posts' )->select ( 1 )->limit( 1 )->get();
+			$this->db::table( 'posts' )->select( '1' )->limit( 1 )->get();
 		} catch ( \Exception $e ) {
 			// Let's not try to create the tables on a blog that's missing the basic ones.
 			return [];


### PR DESCRIPTION
When adding a network site to a multisite install, `is_blog_installed()` is called before the core tables for the site are created. If expected tables are missing, `is_blog_installed()` sets $wpdb->error and calls `dead_db()`, resulting in the following message: "One or more database tables are unavailable. The database may need to be repaired."

The issue persists on future requests because the function is called before the core tables are created, leaving the site in a partially created state. Checking `wp_installing()` before `is_blog_installed()` prevents the issue on fresh installs, but does not fix the issue for sites already in this state.

I decided to revert the changes since the previous implementation is known to work reliably.

An alternative approach could be to use `wp_is_site_initialized( get_current_blog_id() )` instead of `is_blog_installed()`. This calls `DESCRIBE {$wpdb->posts}` which may be more overhead than just selecting one row.

https://github.com/user-attachments/assets/86cde459-0da5-42e0-bbff-0b84d07c8c64

