### PR TITLE
Fixing error during update evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adhere to the [Semantic Versioning](http://semver.org/) standard.
 
+## [3.1.2] 2025-10-02
+
+* Fix - Fix the `update_many` method to properly check if the transaction was successful.
+
+[3.1.2]: https://github.com/stellarwp/schema/releases/tag/3.1.2
+
 ## [3.1.1] 2025-10-01
 
 * Tweak - Fix the `get_all_by` method to accept an order by clause.

--- a/src/Schema/Traits/Custom_Table_Query_Methods.php
+++ b/src/Schema/Traits/Custom_Table_Query_Methods.php
@@ -392,7 +392,7 @@ trait Custom_Table_Query_Methods {
 			$results[] = $database::query( $query );
 		}
 
-		$all_good = count( array_filter( $results ) ) === count( $results );
+		$all_good = count( array_filter( $results, static fn( $result ) => $result !== false ) ) === count( $results );
 
 		if ( ! $all_good ) {
 			$database::rollBack();


### PR DESCRIPTION
The correct evaluation of a good or bad batch update should be that no results are false. Falsy is fine like `0`. That would simply mean that no rows were affected.